### PR TITLE
Add JSON schemas to VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+    "json.schemas": [
+        {
+          "fileMatch": [
+            "/bees.json"
+          ],
+          "url": "/bees.schema.json"
+        },
+        {
+          "fileMatch": [
+            "/flowers.json"
+          ],
+          "url": "/flowers.schema.json"
+        }
+    ]
+}


### PR DESCRIPTION
VS Code will now show issues in our JSON files when they don't match the schemas.