### PR TITLE
Split the "commonly attracted bees" off from the main flower description

### DIFF
--- a/flowers.json
+++ b/flowers.json
@@ -35,7 +35,10 @@
       "blooming_period": [
         "--06-01/--08-31"
       ],
-      "description": "Asclepias syriaca, or common milkweed, is a tall perennial plant that grows in sunny areas and flowers from June to August. It has pink flowers and green leaves. Common milkweed attracts lots of kinds of insects both to feed on the nectar from the flowers and to lay eggs. This is an important plant to the monarch butterfly, Danaus plexippus. The monarch butterfly lays its eggs on the leaves, and when the eggs hatch, the larvae eat the leaves before turning into butterflies. Common milkweed commonly attracts these bees: Megachile (leafcutter bees), Bombus (bumble bees), Halictus (sweat bees), and Coelioxys (cuckoo bees)."
+      "description": {
+        "summary": "Asclepias syriaca, or common milkweed, is a tall perennial plant that grows in sunny areas and flowers from June to August. It has pink flowers and green leaves. Common milkweed attracts lots of kinds of insects both to feed on the nectar from the flowers and to lay eggs. This is an important plant to the monarch butterfly, Danaus plexippus. The monarch butterfly lays its eggs on the leaves, and when the eggs hatch, the larvae eat the leaves before turning into butterflies.",
+        "bees_attracted": "Common milkweed commonly attracts these bees: Megachile (leafcutter bees), Bombus (bumble bees), Halictus (sweat bees), and Coelioxys (cuckoo bees)."
+      }
     },
     "cirsium_discolor": {
       "name": "field thistle",
@@ -59,7 +62,10 @@
       "blooming_period": [
         "--06-30/--10-01"
       ],
-      "description": "Cirsium discolor, or field thistle, is a tall flowering plant with large pink flower heads and a long flowering period. Native thistles like the field thistle are very important forage plants for bees. The field thistle grows in upland sunny areas and flowers from July to October. Field thistle commonly attracts these bees: Bombus (bumble bees), Megachile (leafcutter bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), and Melissodes (long-horned bees)."
+      "description": {
+        "summary": "Cirsium discolor, or field thistle, is a tall flowering plant with large pink flower heads and a long flowering period. Native thistles like the field thistle are very important forage plants for bees. The field thistle grows in upland sunny areas and flowers from July to October.",
+        "bees_attracted": "Field thistle commonly attracts these bees: Bombus (bumble bees), Megachile (leafcutter bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), and Melissodes (long-horned bees)."
+      }
     },
     "echinacea_angustifolia": {
       "name": "narrow-leaved purple coneflower",
@@ -83,7 +89,10 @@
       "blooming_period": [
         "--06-01/--10-31"
       ],
-      "description": "Echinacea angustifolia, or narrow-leaved purple coneflower, is a native prairie plant. It grows in dry, sunny areas and flowers from June to October. The purple coneflower has green, fuzzy leaves and stems with purple or pink petals and an orange-brown center disk. Many Native American groups used this plant for a variety of medicinal purposes, including pain relief and relief of colds and toothaches. Purple coneflower commonly attracts these bees: Andrena (mining bees), Bombus (bumble bees), Ceratina (small carpenter bees), Melissodes (long-horned bees), Hylaeus (yellow-faced or masked bees), Agapostemon (metallic green sweat bees), Augochlorella (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Coelioxys (cuckoo bees), Heriades (small resin bees), Megachile (leafcutter bees), Anthidium (wool carder bees), and Xylocopa (large carpenter bees)."
+      "description": {
+        "summary": "Echinacea angustifolia, or narrow-leaved purple coneflower, is a native prairie plant. It grows in dry, sunny areas and flowers from June to October. The purple coneflower has green, fuzzy leaves and stems with purple or pink petals and an orange-brown center disk. Many Native American groups used this plant for a variety of medicinal purposes, including pain relief and relief of colds and toothaches.",
+        "bees_attracted": "Purple coneflower commonly attracts these bees: Andrena (mining bees), Bombus (bumble bees), Ceratina (small carpenter bees), Melissodes (long-horned bees), Hylaeus (yellow-faced or masked bees), Agapostemon (metallic green sweat bees), Augochlorella (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Coelioxys (cuckoo bees), Heriades (small resin bees), Megachile (leafcutter bees), Anthidium (wool carder bees), and Xylocopa (large carpenter bees)."
+      }
     },
     "rubus_occidentalis": {
       "name": "black raspberry",
@@ -107,7 +116,10 @@
       "blooming_period": [
         "--05-01/--06-30"
       ],
-      "description": "Rubus occidentalis, or black raspberry, is a common native plant frequently found along roadsides and hiking trails. It produces white flowers from May to June. After it is pollinated, it makes dark berries (black raspberries) that are edible to humans and other mammals. Black raspberry commonly attracts these bees: Bombus (bumble bees), Osmia (mason bees), Megachile (leafcutter bees), Nomada (cuckoo bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Augochloropsis (metallic green sweat bees), Augochlorella (metallic green sweat bees), Augochlora (metallic green sweat bees), Andrena (mining bees), and Calliopsis (mining bees)."
+      "description": {
+        "summary": "Rubus occidentalis, or black raspberry, is a common native plant frequently found along roadsides and hiking trails. It produces white flowers from May to June. After it is pollinated, it makes dark berries (black raspberries) that are edible to humans and other mammals.",
+        "bees_attracted": "Black raspberry commonly attracts these bees: Bombus (bumble bees), Osmia (mason bees), Megachile (leafcutter bees), Nomada (cuckoo bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Augochloropsis (metallic green sweat bees), Augochlorella (metallic green sweat bees), Augochlora (metallic green sweat bees), Andrena (mining bees), and Calliopsis (mining bees)."
+      }
     },
     "monarda_fistulosa": {
       "name": "wild bergamot",
@@ -131,7 +143,10 @@
       "blooming_period": [
         "--06-20/--08-20"
       ],
-      "description": "Monarda fistulosa, or wild bergamot, is a fast-spreading plant that lives in upland sunny areas. It produces light or dark pink flowers from late June to September. The flowers attract many insects who are looking for some pollen but mostly nectar. Wild bergamot was considered a medicinal plant by many Native Americans including the Menominee, the Ojibwe, and the Winnebago (Ho-Chunk). It was used most commonly to treat colds, and was frequently made into a tea. Today, many families still use wild bergamot during the cold and flu season. Wild Bergamot commonly attracts these bees: Bombus (bumble bees), Anthophora (digger bees), Melissodes (long-horned bees), Megachile (leafcutter bees), and Agapostemon (metallic green sweat bees)."
+      "description": {
+        "summary": "Monarda fistulosa, or wild bergamot, is a fast-spreading plant that lives in upland sunny areas. It produces light or dark pink flowers from late June to September. The flowers attract many insects who are looking for some pollen but mostly nectar. Wild bergamot was considered a medicinal plant by many Native Americans including the Menominee, the Ojibwe, and the Winnebago (Ho-Chunk). It was used most commonly to treat colds, and was frequently made into a tea. Today, many families still use wild bergamot during the cold and flu season.",
+        "bees_attracted": "Wild Bergamot commonly attracts these bees: Bombus (bumble bees), Anthophora (digger bees), Melissodes (long-horned bees), Megachile (leafcutter bees), and Agapostemon (metallic green sweat bees)."
+      }
     },
     "prunus_americana": {
       "name": "wild plum",
@@ -167,7 +182,10 @@
       "blooming_period": [
         "--04-15/--06-15"
       ],
-      "description": "Prunus americana, or wild plum, is a small native tree with white flowers. After flowering from April to June, it produces plum fruits in August and September. This tree is common on the edges of woodlands, in old field margins, and in prairies. Wild plum is self-incompatible and extremely fragrant, which attracts a large number of insects for both pollen and nectar. Wild plum commonly attracts these bees: Andrena (mining bees), Lasioglossum (small sweat bees), Colletes (cellophane bees), Bombus (bumble bees), Osmia (mason bees), and Nomada (cuckoo bees)."
+      "description": {
+        "summary": "Prunus americana, or wild plum, is a small native tree with white flowers. After flowering from April to June, it produces plum fruits in August and September. This tree is common on the edges of woodlands, in old field margins, and in prairies. Wild plum is self-incompatible and extremely fragrant, which attracts a large number of insects for both pollen and nectar.",
+        "bees_attracted": "Wild plum commonly attracts these bees: Andrena (mining bees), Lasioglossum (small sweat bees), Colletes (cellophane bees), Bombus (bumble bees), Osmia (mason bees), and Nomada (cuckoo bees)."
+      }
     },
     "rudbeckia_hirta": {
       "name": "black-eyed Susan",
@@ -191,7 +209,10 @@
       "blooming_period": [
         "--05-20/--09-20"
       ],
-      "description": "Rudbeckia hirta, or black-eyed Susan, is a short-lived native plant and is often one of the first plants to flower in prairie restoration. It has yellow petals with a dark brown center with coarse bright green leaves. The plant also is a traditional Native American medicinal herb in several tribal nations believed in those cultures to be a remedy, among other things, for colds, flu, infection, swelling and for snake bite (although not all parts of the plant are edible). Black-eyed Susan flowers from June to September. Black-eyed Susan commonly attracts these bees: Melissodes (long-horned bees), Agapostemon and Augochlorella (metallic green sweat bees), Halticus (sweat bees), Bombus (bumble bees), Megachile (leafcutter bees), and Coelioxys (cuckoo bees)."
+      "description": {
+        "summary": "Rudbeckia hirta, or black-eyed Susan, is a short-lived native plant and is often one of the first plants to flower in prairie restoration. It has yellow petals with a dark brown center with coarse bright green leaves. The plant also is a traditional Native American medicinal herb in several tribal nations believed in those cultures to be a remedy, among other things, for colds, flu, infection, swelling and for snake bite (although not all parts of the plant are edible). Black-eyed Susan flowers from June to September.",
+        "bees_attracted": "Black-eyed Susan commonly attracts these bees: Melissodes (long-horned bees), Agapostemon and Augochlorella (metallic green sweat bees), Halticus (sweat bees), Bombus (bumble bees), Megachile (leafcutter bees), and Coelioxys (cuckoo bees)."
+      }
     },
     "solidago_rigida": {
       "name": "stiff goldenrod",
@@ -221,7 +242,10 @@
       "blooming_period": [
         "--07-20/--10-31"
       ],
-      "description": "Solidago rigida, or stiff goldenrod, is an upright perennial with yellow or orange flowers. It is often used in sunny gardens, prairie plantings or restorations. Besides bees, the flowers attract a wide variety of flower-visiting insects. The Ojibwe traditionally used the root as an enema and took an infusion of the root to treat 'stoppage of urine.' The Meskwaki traditionally made the flowers into a lotion and used them on bee stings and for swollen faces. Stiff goldenrod flowers from August to October and commonly attracts these bees: Agapostemon and Augochlorella (metallic green sweat bees), Melissodes (long-horned bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Megachile (leafcutter bees), Ceratina (small carpenter bees), Hylaeus (yellow-faced bees), Andrena (mining bees), and Bombus (bumble bees)."
+      "description": {
+        "summary": "Solidago rigida, or stiff goldenrod, is an upright perennial with yellow or orange flowers. It is often used in sunny gardens, prairie plantings or restorations. Besides bees, the flowers attract a wide variety of flower-visiting insects. The Ojibwe traditionally used the root as an enema and took an infusion of the root to treat 'stoppage of urine.' The Meskwaki traditionally made the flowers into a lotion and used them on bee stings and for swollen faces.",
+        "bees_attracted": "Stiff goldenrod flowers from August to October and commonly attracts these bees: Agapostemon and Augochlorella (metallic green sweat bees), Melissodes (long-horned bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Megachile (leafcutter bees), Ceratina (small carpenter bees), Hylaeus (yellow-faced bees), Andrena (mining bees), and Bombus (bumble bees)."
+      }
     },
     "taraxacum_officinale": {
       "name": "common dandelion",
@@ -245,7 +269,10 @@
       "blooming_period": [
         "--04-01/--09-30"
       ],
-      "description": "Taraxacum officinale, or common dandelion, is an introduced plant from Europe and is extremely common. It is considered a weed in most places but it is sometimes used as a medical herb and in food preparation. Common dandelion can be found growing in temperate regions of the world, in lawns, on roadsides, on disturbed banks and shores of water ways, and other areas with moist soils. Common dandelion is well known for its yellow flower heads that turn into round balls of silver tufted fruits that disperse in the wind. The common name comes from the French “dent de lion”—tooth of lion—referring to the sharp leaf lobes. Common dandelion attracts an extremely large range of pollinators but only in times of extreme need (the quality of the pollen is low). Common Dandelion attracts these bees: Colletes (cellophane bees), Hylaeus (yellow-faced bees), Andrena (mining bees), Calliopsis (mining bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Augochloropsis and Augochlorella and Augochlora (metallic green sweat bees), Osmia (mason bees), Megachile (leafcutter bees), Hoplitis (mason bees), Heriades (small resin bees), Anthidium (wool carder bees), Bombus (bumble bees), Anthophora (digger bees), Melissodes (long-horned bees), Ceratina (small carpenter bees), and Xylocopa (large carpenter bees)."
+      "description": {
+        "summary": "Taraxacum officinale, or common dandelion, is an introduced plant from Europe and is extremely common. It is considered a weed in most places but it is sometimes used as a medical herb and in food preparation. Common dandelion can be found growing in temperate regions of the world, in lawns, on roadsides, on disturbed banks and shores of water ways, and other areas with moist soils. Common dandelion is well known for its yellow flower heads that turn into round balls of silver tufted fruits that disperse in the wind. The common name comes from the French “dent de lion”—tooth of lion—referring to the sharp leaf lobes. Common dandelion attracts an extremely large range of pollinators but only in times of extreme need (the quality of the pollen is low).",
+        "bees_attracted": "Common Dandelion attracts these bees: Colletes (cellophane bees), Hylaeus (yellow-faced bees), Andrena (mining bees), Calliopsis (mining bees), Agapostemon (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Augochloropsis and Augochlorella and Augochlora (metallic green sweat bees), Osmia (mason bees), Megachile (leafcutter bees), Hoplitis (mason bees), Heriades (small resin bees), Anthidium (wool carder bees), Bombus (bumble bees), Anthophora (digger bees), Melissodes (long-horned bees), Ceratina (small carpenter bees), and Xylocopa (large carpenter bees)."
+      }
     },
     "trifolium_repens": {
       "name": "white clover",
@@ -275,7 +302,10 @@
       "blooming_period": [
         "--05-01/--10-31"
       ],
-      "description": "Trifolium repens, or white clover, is native from Europe to western Asia and into north Africa but has been introduced as a forage species for livestock throughout the world. Although it isn’t native to the area, it is often used for foraging by bees. White clover is often used by honey bees for nectar, which then makes clover honey. Some people are replacing their grass lawns with clover because it’s easier and cheaper to take care of. White clover has green stem and leaves with white flowering heads and flowers from May to October. White clover attracts these bees: Bombus (bumble bees), Andrena (mining bees), Ceratina (small carpenter bees), Osmia (mason bees), Agapostemon and Augochlorella (metallic green sweat bees), Halictus (sweat bees), and Lasioglossum (small sweat bees)."
+      "description": {
+        "summary": "Trifolium repens, or white clover, is native from Europe to western Asia and into north Africa but has been introduced as a forage species for livestock throughout the world. Although it isn’t native to the area, it is often used for foraging by bees. White clover is often used by honey bees for nectar, which then makes clover honey. Some people are replacing their grass lawns with clover because it’s easier and cheaper to take care of. White clover has green stem and leaves with white flowering heads and flowers from May to October.",
+        "bees_attracted": "White clover attracts these bees: Bombus (bumble bees), Andrena (mining bees), Ceratina (small carpenter bees), Osmia (mason bees), Agapostemon and Augochlorella (metallic green sweat bees), Halictus (sweat bees), and Lasioglossum (small sweat bees)."
+      }
     },
     "vaccinium_angustifolium": {
       "name": "lowbush blueberry",
@@ -311,7 +341,10 @@
       "blooming_period": [
         "--05-01/--06-30"
       ],
-      "description": "Vaccinium angustifolium, or lowbush blueberry, is a flowering and fruiting plant that is common and widespread on Northern and Northeastern forests. Lowbush blueberry produces white, bell-shaped flowers that produce edible berries after pollination. The lowbush blueberry plant is fire-tolerant and its numbers often increase in an area following a forest fire. While honey bees are often brought to pollinate commercially-grown lowbush blueberries, sometimes bumble bees are used because of their ability to use sonication to pollinate the flowers and because they can fly in colder, wetter conditions than honey bees. The lowbush blueberry commonly attracts these bees: Andrena (mining bees), Bombus (bumble bees), Osmia (mason bees), Lasioglossum (small sweat bees), and Halictus (sweat bees)."
+      "description": {
+        "summary": "Vaccinium angustifolium, or lowbush blueberry, is a flowering and fruiting plant that is common and widespread on Northern and Northeastern forests. Lowbush blueberry produces white, bell-shaped flowers that produce edible berries after pollination. The lowbush blueberry plant is fire-tolerant and its numbers often increase in an area following a forest fire. While honey bees are often brought to pollinate commercially-grown lowbush blueberries, sometimes bumble bees are used because of their ability to use sonication to pollinate the flowers and because they can fly in colder, wetter conditions than honey bees.",
+        "bees_attracted": "The lowbush blueberry commonly attracts these bees: Andrena (mining bees), Bombus (bumble bees), Osmia (mason bees), Lasioglossum (small sweat bees), and Halictus (sweat bees)."
+      }
     },
     "helianthus_maximiliani": {
       "name": "Maximilian sunflower",
@@ -335,229 +368,259 @@
       "blooming_period": [
         "--07-01/--10-31"
       ],
-      "description": "Helianthus maximiliani, or Maximilian sunflower, is a native prairie plant that grows in dry sunny areas. This flower provides food for deer, birds, and many native pollinators. It also provides habitat for songbirds and insects. The Maximilian sunflower can grow from 2 to 10 feet tall. It produces yellow flowers from July to October. The Maximilian sunflower commonly attracts these bees: Bombus (bumble bees), Halictus (sweat bees), Melissodes (long-horned bees), and Lasioglossum (small sweat bees)."
-    },
-      "dalea_purpurea": {
-        "name": "purple prairie clover",
-        "sci_name": "Dalea purpurea",
-        "relative_size": 1.0,
-        "art_file": "Dalea_purpurea.png",
-        "photo_files": [
-          {
-            "filename": "PG041.jpg",
-            "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-            "caption": "The flowering head of the Purple Priaire Clover plant. Photo taken in 2003.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/purple-prairie-clover"
-          },
-          {
-            "filename": "PG042.jpg",
-            "attribution": "© morganwalder, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "Some Purple Prairie Clover plants within a thicket. Photo taken in 2019 in Findlay, IL.",
-            "image_link": "https://www.inaturalist.org/photos/71666623"
-          },
-          {
-            "filename": "PG043.jpg",
-            "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
-            "caption": "Bumble bees visiting the flowers of Purple Prairie Clovers plants. Photo taken in 2008 at Long Lake Regional Park, Ramsey County, MN.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/purple-prairie-clover"
-          }
-        ],
-        "blooming_period": [
-          "--06-01/--08-15"
-        ],
-        "description": "Dalea purpurea, or purple prairie clover, is a low-growing bushy perennial with pink or purple flowers arranged in a spike. Purple prairie clover can grow in a variety of soils and blooms from June to mid-August. The flowers attract a wide variety of native bee species. Purple prairie clover commonly attracts these bees: Bombus (bumble bees), Agapostemon and Augochlorella (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), and Coelioxys and Triepeolus (cuckoo bees)."
-      },
-      "eutrochium_maculatum": {
-        "name": "spotted Joe Pye weed",
-        "sci_name": "Eutrochium maculatum",
-        "relative_size": 2.0,
-        "art_file": "Eutrochium_maculatum.png",
-        "photo_files": [
-          {
-            "filename": "PG037.jpg",
-            "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-            "caption": "A blooming Spotted Jow Pye-Weed plant. Photo taken in 2004 in Anoka or Aitkin counties, Minnesota.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/spotted-joe-pye-weed"
-          },
-          {
-            "filename": "PG038.jpeg",
-            "attribution": "© Laurie DiCesare, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "Some Spotted Joe Pye-Weed plants next to a pond. Photo taken in 2018 in Colchester, VT.",
-            "image_link": "https://www.inaturalist.org/photos/72619281"
-          }
-        ],
-        "blooming_period": [
-          "--07-01/--09-01"
-        ],
-        "description": "Eutrochium maculatum, or spotted Joe Pye weed, is a perennial with large pink flower heads and maroon stems with spots and blooms from July to September. It is common in sites with moist soil. Besides attracting bees, spotted Joe Pye weed attracts a number of butterfly species and nocturnal moths. Most bees visit the flowers for nectar and sometimes pollen. spotted Joe Pye weed commonly attracts these bees: Bombus (bumble bees), Megachile (leafcutter bees), Coelioxys (cuckoo bees), Agapostemon (metallic green sweat bees), and Melissodes (long-horned bees)."
-      },
-      "liatris_aspera": {
-        "name": "rough blazing star",
-        "sci_name": "Liatris aspera",
-        "relative_size": 1.2,
-        "art_file": "Liatris_aspera.png",
-        "photo_files": [
-          {
-            "filename": "PG039.jpg",
-            "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
-            "caption": "The flowers of the Rough Blazing Star plant. Photo taken in 2007 in central MN.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/rough-blazing-star"
-          },
-          {
-            "filename": "PG040.jpeg",
-            "attribution": "© Brent J. Anderson, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "A Rough Blazing Star plant with a visiting bumble bee. Photo taken in 2015 at Mound Prairie Township, MN.",
-            "image_link": "https://www.inaturalist.org/photos/53449608"
-          }
-        ],
-        "blooming_period": [
-          "--07-01/--09-01"
-        ],
-        "description": "Liatris aspera, or rough blazing star, is a native perennial plant with many button-like pink or purple flowers along a flowering stalk and blooms from July to September. The flowers attract a number of bees, butterflies, and hummingbirds in late summer. Rough blazing star commonly attracts these bees: Bombus (bumble bees), Ceratina (small carpenter bees), Megachile (leafcutter bees), Agapostemon (metallic green sweat bees), and Lasioglossum (small sweat bees)."
-      },
-      "symphyotrichum_oolentangiense": {
-        "name": "sky blue aster",
-        "sci_name": "Symphyotrichum oolentangiense",
-        "relative_size": 1.1,
-        "art_file": "Symphyotrichum_oolentangiense.png",
-        "photo_files": [
-          {
-            "filename": "PG044.jpeg",
-            "attribution": "© jim_keesling, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "The Sky Blue Aster plant in a field. Photo taken in 2017 in Little River County, AR.",
-            "image_link": "https://www.inaturalist.org/photos/53957713"
-          },
-          {
-            "filename": "PG045.jpeg",
-            "attribution": "© psweet, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "The flowers of the Sky Blue Aster plant. Photo taken in 2019 in Lake County, IL.",
-            "image_link": "https://www.inaturalist.org/photos/53433850"
-          }
-        ],
-        "blooming_period": [
-          "--08-15/--10-01"
-        ],
-        "description": "Symphyotrichum oolentangiense, or sky blue aster, is a common dry-prairie plant with light blue or violet flowers and yellow to orange disc florets. Sky blue aster grows in part-shade to sunny areas and blooms from mid-August to October. Sky blue aster attracts these bees: Agapostemon and Augochlorella and Augochloropsis (metallic green sweat bees), Melissodes (long-horned bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Ceratina (small carpenter bees), Andrena (mining bees), and Bombus (bumble bees)."
-      },
-      "verbena_stricta": {
-        "name": "hoary vervain",
-        "sci_name": "Verbena stricta",
-        "relative_size": 1.0,
-        "art_file": "Verbena_stricta.png",
-        "photo_files": [
-          {
-            "filename": "PG046.jpg",
-            "attribution": "© leannmichael, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "A butterfly enjoying nectar from Hoary Vervain flowers. Photo taken in 2019 in Lino Lakes, MN.",
-            "image_link": "https://www.inaturalist.org/photos/48412496"
-          },
-          {
-            "filename": "PG047.jpg",
-            "attribution": "© Kent McFarland, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "Clumps of Hoary Vervain plants. Photo taken in 2010 in Riley, KS",
-            "image_link": "https://www.inaturalist.org/photos/58278122"
-          }
-        ],
-        "blooming_period": [
-          "--07-01/--09-01"
-        ],
-        "description": "Verbena stricta, or hoary vervain, is a narrow upright perennial with long flower spikes that have blue or purple flower petals. Hoary vervain can often be found in compacted sandy soil or in a prairie or prairie restoration site. Flowers bloom from July to September and develop from the bottom up, providing a longer supply of nectar and pollen for visiting insects. Hoary vervain commonly attracts these bees: Agapostemon (metallic green sweat bees), Megachile (leafcutter bees), Melissodes (long-horned bees), Calliopsis (mining bees), Bombus (bumble bees), and Nomada, Coelioxys, Epeolus, and Triepeolus (cuckoo bees)."
-      },
-      "veronicastrum_virginicum": {
-        "name": "Culver's root",
-        "sci_name": "Veronicastrum virginicum",
-        "relative_size": 2.0,
-        "art_file": "Veronicastrum_virginicum.png",
-        "photo_files": [
-          {
-            "filename": "PG048.jpg",
-            "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-            "caption": "The flower heads of the Culver's Root plant. Photo taken in 2003 in Anoka County, MN.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/culvers-root"
-          },
-          {
-            "filename": "PG049.jpg",
-            "attribution": "© Janet Novak, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "Culver's Root plant in native habitat. Photo taken in 2019 in Portsmouth, OH.",
-            "image_link": "https://www.inaturalist.org/photos/48099122"
-          }
-        ],
-        "blooming_period": [
-          "--07-01/--09-01"
-        ],
-        "description": "Veronicastrum virginicum, or Culver’s root, is a perennial flower with tall stalks and small white flowers arranged in spikes. Individual flowers bloom for over a month, attracting bees, wasps, and soldier beetles. Culver’s root blooms from July to September and grows in woodland edge or prairie habitats. Culver’s root commonly attracts these bees: Lasioglossum (small sweat bees), Hylaeus (yellow-faced bees), Halictus (sweat bees), Megachile (leafcutter bees), Melissodes (long-horned bees), and Bombus (bumble bees)."
-      },
-      "zizia_aurea": {
-        "name": "golden alexanders",
-        "sci_name": "Zizia aurea",
-        "relative_size": 1.0,
-        "art_file": "Zizia_aurea.png",
-        "photo_files": [
-          {
-            "filename": "PG050.jpg",
-            "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-            "caption": "A clump of Golden Alexanders in a garden. Photo taken in 2003.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/golden-alexanders"
-          },
-          {
-            "filename": "PG051.jpg",
-            "attribution": "© bkmertz, iNaturalist.org, (CC BY-NC 4.0).",
-            "caption": "The flower heads of the Golden Alexanders plant. Photo taken in 2020 in North Salem, NY.",
-            "image_link": "https://www.inaturalist.org/photos/73230163"
-          }
-        ],
-        "blooming_period": [
-          "--04-15/--06-15"
-        ],
-        "description": "Zizia aurea, or golden alexanders, is a perennial with green stalks and leaves with clusters of yellow to orange flowers. Golden alexanders grows in a wide variety of soil types and blooms from mid-April to mid-June. These plants attract many flower-visiting insects and most visit for the nectar. Golden alexanders commonly attracts these bees: Ceratina (small carpenter bees), Lasioglossum (small sweat bees), Hylaeus (yellow-faced bees), Andrena (mining bees), Bombus (bumble bees), and Osmia (mason bees)."
-      },
-      "coreopsis_palmata": {
-        "name": "prairie coreopsis",
-        "sci_name": "Coreopsis palmata",
-        "relative_size": 1.0,
-        "art_file": "Coreopsis_palmata.png",
-        "photo_files": [
-          {
-            "filename": "PG035.jpg",
-            "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
-            "caption": "Prairie Coreopsis flower heads. Photo taken in 2008 at Long Lake Regional Park, Ramsay County, Minnesota.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/prairie-coreopsis"
-          },
-          {
-            "filename": "PG036.jpg",
-            "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-            "caption": "A cluster of Prairie Coreopsis plants. Photo taken in 2011.",
-            "image_link": "https://www.minnesotawildflowers.info/flower/prairie-coreopsis"
-          }
-        ],
-        "blooming_period": [
-          "--06-01/--08-01"
-        ],
-        "description": "Coreopsis palmata, or prairie coreopsis, is a short perennial with yellow-orange flower heads and dark green leaves. Prairie coreopsis grows in sunny areas and prairie landscapes and flowers from June to August. The open flower heads provide access to pollen and nectar for all bees, especially short-tongued bees. Prairie coreopsis also attracts butterflies, moths, beetles, wasps, syrphid flies, and ants. Prairie coreopsis commonly attracts these bees: Ceratina (small carpenter bees), Megachile (leafcutter bees), Heraides (small resin bees), Melissodes (long-horned bees), and Coelioxys (cuckoo bees)."
-      },
-        "achillea_millefolium": {
-          "name": "common yarrow",
-          "sci_name": "Achillea millefolium",
-          "relative_size": 1.0,
-          "art_file": "Achillea_millefolium.png",
-          "photo_files": [
-            {
-              "filename": "PG033.jpg",
-              "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
-              "caption": "A cluster of Common Yarrow flowers. Photo taken in 2004 in Anoka or Lake County.",
-              "image_link": "https://www.minnesotawildflowers.info/flower/common-yarrow"
-            },
-            {
-              "filename": "PG034.jpeg",
-              "attribution": "© kttharp, iNaturalist.org, (CC BY-NC 4.0).",
-              "caption": "The Common Yarrow plant. Photo taken May 12, 2020 in Austin TX.",
-              "image_link": "https://www.inaturalist.org/photos/73352070"
-            }
-          ],
-          "blooming_period": [
-            "--06-15/--09-01"
-          ],
-          "description": "Achillea millefolium, or common yarrow, is an upright perennial that grows in part shade, fields, or prairie and flowers from mid June to September. It has white flowers and green, fern-like leaves. These flowers are self-incompatible and rely on insects for pollination. Common yarrow has been used for a variety of ailments including wounds, burns, fevers, colds, and headaches. Common yarrow commonly attracts these bees: Lasioglossum (small sweat bees), Ceratina (small carpenter bees), Megachile (leafcutter bees), Andrena (mining bees), and Nomada (cuckoo bees)."
+      "description": {
+        "summary": "Helianthus maximiliani, or Maximilian sunflower, is a native prairie plant that grows in dry sunny areas. This flower provides food for deer, birds, and many native pollinators. It also provides habitat for songbirds and insects. The Maximilian sunflower can grow from 2 to 10 feet tall. It produces yellow flowers from July to October.",
+        "bees_attracted": "The Maximilian sunflower commonly attracts these bees: Bombus (bumble bees), Halictus (sweat bees), Melissodes (long-horned bees), and Lasioglossum (small sweat bees)."
       }
+    },
+    "dalea_purpurea": {
+      "name": "purple prairie clover",
+      "sci_name": "Dalea purpurea",
+      "relative_size": 1.0,
+      "art_file": "Dalea_purpurea.png",
+      "photo_files": [
+        {
+          "filename": "PG041.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "The flowering head of the Purple Priaire Clover plant. Photo taken in 2003.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/purple-prairie-clover"
+        },
+        {
+          "filename": "PG042.jpg",
+          "attribution": "© morganwalder, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "Some Purple Prairie Clover plants within a thicket. Photo taken in 2019 in Findlay, IL.",
+          "image_link": "https://www.inaturalist.org/photos/71666623"
+        },
+        {
+          "filename": "PG043.jpg",
+          "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
+          "caption": "Bumble bees visiting the flowers of Purple Prairie Clovers plants. Photo taken in 2008 at Long Lake Regional Park, Ramsey County, MN.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/purple-prairie-clover"
+        }
+      ],
+      "blooming_period": [
+        "--06-01/--08-15"
+      ],
+      "description": {
+        "summary": "Dalea purpurea, or purple prairie clover, is a low-growing bushy perennial with pink or purple flowers arranged in a spike. Purple prairie clover can grow in a variety of soils and blooms from June to mid-August. The flowers attract a wide variety of native bee species.",
+        "bees_attracted": "Purple prairie clover commonly attracts these bees: Bombus (bumble bees), Agapostemon and Augochlorella (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), and Coelioxys and Triepeolus (cuckoo bees)."
+      }
+    },
+    "eutrochium_maculatum": {
+      "name": "spotted Joe Pye weed",
+      "sci_name": "Eutrochium maculatum",
+      "relative_size": 2.0,
+      "art_file": "Eutrochium_maculatum.png",
+      "photo_files": [
+        {
+          "filename": "PG037.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "A blooming Spotted Jow Pye-Weed plant. Photo taken in 2004 in Anoka or Aitkin counties, Minnesota.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/spotted-joe-pye-weed"
+        },
+        {
+          "filename": "PG038.jpeg",
+          "attribution": "© Laurie DiCesare, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "Some Spotted Joe Pye-Weed plants next to a pond. Photo taken in 2018 in Colchester, VT.",
+          "image_link": "https://www.inaturalist.org/photos/72619281"
+        }
+      ],
+      "blooming_period": [
+        "--07-01/--09-01"
+      ],
+      "description": {
+        "summary": "Eutrochium maculatum, or spotted Joe Pye weed, is a perennial with large pink flower heads and maroon stems with spots and blooms from July to September. It is common in sites with moist soil. Besides attracting bees, spotted Joe Pye weed attracts a number of butterfly species and nocturnal moths. Most bees visit the flowers for nectar and sometimes pollen.",
+        "bees_attracted": "Spotted Joe Pye weed commonly attracts these bees: Bombus (bumble bees), Megachile (leafcutter bees), Coelioxys (cuckoo bees), Agapostemon (metallic green sweat bees), and Melissodes (long-horned bees)."
+      }
+    },
+    "liatris_aspera": {
+      "name": "rough blazing star",
+      "sci_name": "Liatris aspera",
+      "relative_size": 1.2,
+      "art_file": "Liatris_aspera.png",
+      "photo_files": [
+        {
+          "filename": "PG039.jpg",
+          "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
+          "caption": "The flowers of the Rough Blazing Star plant. Photo taken in 2007 in central MN.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/rough-blazing-star"
+        },
+        {
+          "filename": "PG040.jpeg",
+          "attribution": "© Brent J. Anderson, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "A Rough Blazing Star plant with a visiting bumble bee. Photo taken in 2015 at Mound Prairie Township, MN.",
+          "image_link": "https://www.inaturalist.org/photos/53449608"
+        }
+      ],
+      "blooming_period": [
+        "--07-01/--09-01"
+      ],
+      "description": {
+        "summary": "Liatris aspera, or rough blazing star, is a native perennial plant with many button-like pink or purple flowers along a flowering stalk and blooms from July to September. The flowers attract a number of bees, butterflies, and hummingbirds in late summer.",
+        "bees_attracted": "Rough blazing star commonly attracts these bees: Bombus (bumble bees), Ceratina (small carpenter bees), Megachile (leafcutter bees), Agapostemon (metallic green sweat bees), and Lasioglossum (small sweat bees)."
+      }
+    },
+    "symphyotrichum_oolentangiense": {
+      "name": "sky blue aster",
+      "sci_name": "Symphyotrichum oolentangiense",
+      "relative_size": 1.1,
+      "art_file": "Symphyotrichum_oolentangiense.png",
+      "photo_files": [
+        {
+          "filename": "PG044.jpeg",
+          "attribution": "© jim_keesling, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "The Sky Blue Aster plant in a field. Photo taken in 2017 in Little River County, AR.",
+          "image_link": "https://www.inaturalist.org/photos/53957713"
+        },
+        {
+          "filename": "PG045.jpeg",
+          "attribution": "© psweet, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "The flowers of the Sky Blue Aster plant. Photo taken in 2019 in Lake County, IL.",
+          "image_link": "https://www.inaturalist.org/photos/53433850"
+        }
+      ],
+      "blooming_period": [
+        "--08-15/--10-01"
+      ],
+      "description": {
+        "summary": "Symphyotrichum oolentangiense, or sky blue aster, is a common dry-prairie plant with light blue or violet flowers and yellow to orange disc florets. Sky blue aster grows in part-shade to sunny areas and blooms from mid-August to October.",
+        "bees_attracted": "Sky blue aster attracts these bees: Agapostemon and Augochlorella and Augochloropsis (metallic green sweat bees), Melissodes (long-horned bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Ceratina (small carpenter bees), Andrena (mining bees), and Bombus (bumble bees)."
+      }
+    },
+    "verbena_stricta": {
+      "name": "hoary vervain",
+      "sci_name": "Verbena stricta",
+      "relative_size": 1.0,
+      "art_file": "Verbena_stricta.png",
+      "photo_files": [
+        {
+          "filename": "PG046.jpg",
+          "attribution": "© leannmichael, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "A butterfly enjoying nectar from Hoary Vervain flowers. Photo taken in 2019 in Lino Lakes, MN.",
+          "image_link": "https://www.inaturalist.org/photos/48412496"
+        },
+        {
+          "filename": "PG047.jpg",
+          "attribution": "© Kent McFarland, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "Clumps of Hoary Vervain plants. Photo taken in 2010 in Riley, KS",
+          "image_link": "https://www.inaturalist.org/photos/58278122"
+        }
+      ],
+      "blooming_period": [
+        "--07-01/--09-01"
+      ],
+      "description": {
+        "summary": "Verbena stricta, or hoary vervain, is a narrow upright perennial with long flower spikes that have blue or purple flower petals. Hoary vervain can often be found in compacted sandy soil or in a prairie or prairie restoration site. Flowers bloom from July to September and develop from the bottom up, providing a longer supply of nectar and pollen for visiting insects.",
+        "bees_attracted": "Hoary vervain commonly attracts these bees: Agapostemon (metallic green sweat bees), Megachile (leafcutter bees), Melissodes (long-horned bees), Calliopsis (mining bees), Bombus (bumble bees), and Nomada, Coelioxys, Epeolus, and Triepeolus (cuckoo bees)."
+      }
+    },
+    "veronicastrum_virginicum": {
+      "name": "Culver's root",
+      "sci_name": "Veronicastrum virginicum",
+      "relative_size": 2.0,
+      "art_file": "Veronicastrum_virginicum.png",
+      "photo_files": [
+        {
+          "filename": "PG048.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "The flower heads of the Culver's Root plant. Photo taken in 2003 in Anoka County, MN.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/culvers-root"
+        },
+        {
+          "filename": "PG049.jpg",
+          "attribution": "© Janet Novak, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "Culver's Root plant in native habitat. Photo taken in 2019 in Portsmouth, OH.",
+          "image_link": "https://www.inaturalist.org/photos/48099122"
+        }
+      ],
+      "blooming_period": [
+        "--07-01/--09-01"
+      ],
+      "description": {
+        "summary": "Veronicastrum virginicum, or Culver’s root, is a perennial flower with tall stalks and small white flowers arranged in spikes. Individual flowers bloom for over a month, attracting bees, wasps, and soldier beetles. Culver’s root blooms from July to September and grows in woodland edge or prairie habitats.",
+        "bees_attracted": "Culver’s root commonly attracts these bees: Lasioglossum (small sweat bees), Hylaeus (yellow-faced bees), Halictus (sweat bees), Megachile (leafcutter bees), Melissodes (long-horned bees), and Bombus (bumble bees)."
+      }
+    },
+    "zizia_aurea": {
+      "name": "golden alexanders",
+      "sci_name": "Zizia aurea",
+      "relative_size": 1.0,
+      "art_file": "Zizia_aurea.png",
+      "photo_files": [
+        {
+          "filename": "PG050.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "A clump of Golden Alexanders in a garden. Photo taken in 2003.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/golden-alexanders"
+        },
+        {
+          "filename": "PG051.jpg",
+          "attribution": "© bkmertz, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "The flower heads of the Golden Alexanders plant. Photo taken in 2020 in North Salem, NY.",
+          "image_link": "https://www.inaturalist.org/photos/73230163"
+        }
+      ],
+      "blooming_period": [
+        "--04-15/--06-15"
+      ],
+      "description": {
+        "summary": "Zizia aurea, or golden alexanders, is a perennial with green stalks and leaves with clusters of yellow to orange flowers. Golden alexanders grows in a wide variety of soil types and blooms from mid-April to mid-June. These plants attract many flower-visiting insects and most visit for the nectar.",
+        "bees_attracted": "Golden alexanders commonly attracts these bees: Ceratina (small carpenter bees), Lasioglossum (small sweat bees), Hylaeus (yellow-faced bees), Andrena (mining bees), Bombus (bumble bees), and Osmia (mason bees)."
+      }
+    },
+    "coreopsis_palmata": {
+      "name": "prairie coreopsis",
+      "sci_name": "Coreopsis palmata",
+      "relative_size": 1.0,
+      "art_file": "Coreopsis_palmata.png",
+      "photo_files": [
+        {
+          "filename": "PG035.jpg",
+          "attribution": "Courtesy Katy Chayka, Minnesota Wildflowers.",
+          "caption": "Prairie Coreopsis flower heads. Photo taken in 2008 at Long Lake Regional Park, Ramsay County, Minnesota.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/prairie-coreopsis"
+        },
+        {
+          "filename": "PG036.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "A cluster of Prairie Coreopsis plants. Photo taken in 2011.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/prairie-coreopsis"
+        }
+      ],
+      "blooming_period": [
+        "--06-01/--08-01"
+      ],
+      "description": {
+        "summary": "Coreopsis palmata, or prairie coreopsis, is a short perennial with yellow-orange flower heads and dark green leaves. Prairie coreopsis grows in sunny areas and prairie landscapes and flowers from June to August. The open flower heads provide access to pollen and nectar for all bees, especially short-tongued bees. Prairie coreopsis also attracts butterflies, moths, beetles, wasps, syrphid flies, and ants.",
+        "bees_attracted": "Prairie coreopsis commonly attracts these bees: Ceratina (small carpenter bees), Megachile (leafcutter bees), Heraides (small resin bees), Melissodes (long-horned bees), and Coelioxys (cuckoo bees)."
+      }
+    },
+    "achillea_millefolium": {
+      "name": "common yarrow",
+      "sci_name": "Achillea millefolium",
+      "relative_size": 1.0,
+      "art_file": "Achillea_millefolium.png",
+      "photo_files": [
+        {
+          "filename": "PG033.jpg",
+          "attribution": "Courtesy Peter M Dziuk, Minnesota Wildflowers.",
+          "caption": "A cluster of Common Yarrow flowers. Photo taken in 2004 in Anoka or Lake County.",
+          "image_link": "https://www.minnesotawildflowers.info/flower/common-yarrow"
+        },
+        {
+          "filename": "PG034.jpeg",
+          "attribution": "© kttharp, iNaturalist.org, (CC BY-NC 4.0).",
+          "caption": "The Common Yarrow plant. Photo taken May 12, 2020 in Austin TX.",
+          "image_link": "https://www.inaturalist.org/photos/73352070"
+        }
+      ],
+      "blooming_period": [
+        "--06-15/--09-01"
+      ],
+      "description": {
+        "summary": "Achillea millefolium, or common yarrow, is an upright perennial that grows in part shade, fields, or prairie and flowers from mid June to September. It has white flowers and green, fern-like leaves. These flowers are self-incompatible and rely on insects for pollination. Common yarrow has been used for a variety of ailments including wounds, burns, fevers, colds, and headaches.",
+        "bees_attracted": "Common yarrow commonly attracts these bees: Lasioglossum (small sweat bees), Ceratina (small carpenter bees), Megachile (leafcutter bees), Andrena (mining bees), and Nomada (cuckoo bees)."
+      }
+    }
   }
 }

--- a/flowers.schema.json
+++ b/flowers.schema.json
@@ -80,7 +80,19 @@
             ]
           },
           "description": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "summary": {
+                "description": "A paragraph describing this flower.",
+                "type": "string"
+              },
+              "bees_attracted": {
+                "description": "A human-readable list of what bees collect pollen from this flower.",
+                "type": "string"
+              }
+            },
+            "required": ["summary"],
+            "additionalProperties": false
           }
         },
         "required": [


### PR DESCRIPTION
Right now, the flowers have descriptions like this:

> Echinacea angustifolia, or narrow-leaved purple coneflower, is a native prairie plant. It grows in dry, sunny areas and flowers from June to October. The purple coneflower has green, fuzzy leaves and stems with purple or pink petals and an orange-brown center disk. Many Native American groups used this plant for a variety of medicinal purposes, including pain relief and relief of colds and toothaches. Purple coneflower commonly attracts these bees: Andrena (mining bees), Bombus (bumble bees), Ceratina (small carpenter bees), Melissodes (long-horned bees), Hylaeus (yellow-faced or masked bees), Agapostemon (metallic green sweat bees), Augochlorella (metallic green sweat bees), Halictus (sweat bees), Lasioglossum (small sweat bees), Coelioxys (cuckoo bees), Heriades (small resin bees), Megachile (leafcutter bees), Anthidium (wool carder bees), and Xylocopa (large carpenter bees).

That last sentence, where we list all the types of bees that like this flower, is wordy, and there's rarely an occasion where we want to display it.

This PR takes that last sentence and puts it in a different field in the JSON. That way, it's there if we still need it, but we can display only the first part of the description everywhere else.