### PR TITLE
Build 512-square bee images

### DIFF
--- a/build-art.js
+++ b/build-art.js
@@ -55,10 +55,6 @@ for (const dirName of ['bees', 'flowers', 'nests']) {
   processDirectory(dirPath, `${resizedDir}/500w/${dirName}`, (file) =>
     sharp(file).resize({width: 500})
   );
-}
-
-for (const dirName of ['flowers', 'nests']) {
-  const dirPath = `${originalDir}/${dirName}`;
 
   processDirectory(
     dirPath,
@@ -70,6 +66,10 @@ for (const dirName of ['flowers', 'nests']) {
       background: { r: 0, g: 0, b: 0, alpha: 0 }
     })
   );
+}
+
+for (const dirName of ['flowers', 'nests']) {
+  const dirPath = `${originalDir}/${dirName}`;
   processDirectory(
     dirPath,
     `${resizedDir}/512-square-grayscale/${dirName}`,


### PR DESCRIPTION
In addition to 512-square flowers and nests.

(I'd like to use these square bee images for the field guide dialog in Buzz About; the layout of that dialog is such that having images with known aspect ratios would be very convenient. See details here: https://github.com/mn-pollinators/buzz-about/issues/257)